### PR TITLE
Find files correctly when they contain diacritics

### DIFF
--- a/lib/etd_transformer/senior_theses_transformer.rb
+++ b/lib/etd_transformer/senior_theses_transformer.rb
@@ -3,6 +3,7 @@
 require 'csv'
 require 'fileutils'
 require 'shellwords'
+require 'cgi'
 
 module EtdTransformer
   ##
@@ -100,14 +101,16 @@ module EtdTransformer
     end
 
     ##
-    # Given a DSpace contents file, return an array of all bundle:CONTENT filenames
+    # Given a DSpace contents file, return an array of all bundle:CONTENT filenames.
+    # DSpace encodes diacritics as HTML entities and those must be unescaped to match
+    # the file name on disk.
     # @return [<String>] An array of all bundle:CONTENT filenames
     def list_extra_files(contents_file)
       parsed = CSV.read(contents_file, col_sep: "\t", quote_char: nil)
       extra_file_pairs = parsed.select { |a| a[1] == "bundle:CONTENT" }
       return [] unless extra_file_pairs
 
-      extra_file_pairs.map(&:first)
+      extra_file_pairs.map(&:first).map { |a| CGI.unescapeHTML(a) }
     end
 
     ##

--- a/spec/etd_transformer/senior_thesis_transformer_spec.rb
+++ b/spec/etd_transformer/senior_thesis_transformer_spec.rb
@@ -112,6 +112,14 @@ RSpec.describe EtdTransformer::SeniorThesesTransformer do
           transformer.copy_contents(vs, ds)
           expect(File.exist?(destination_path)).to eq true
         end
+        context 'diacritics' do
+          let(:diacritics_contents_file) { "#{$fixture_path}/diacritics/contents" }
+          it 'translates to UTF8 so it can find files with diacritics on disk' do
+            extra_files = transformer.list_extra_files(diacritics_contents_file)
+            expected_file_name = "MASSIE, Katie '21_Résume de ma Thèse_FINAL.pdf"
+            expect(extra_files.first).to eq expected_file_name
+          end
+        end
       end
       context 'when there are no extra files' do
         let(:ds) { transformer.dataspace_submissions.last }
@@ -127,6 +135,7 @@ RSpec.describe EtdTransformer::SeniorThesesTransformer do
       transformer.copy_license_file(ds)
       expect(File.exist?(destination_path)).to eq true
     end
+
     it 'creates a collection import file' do
       destination_path = File.join(ds.directory_path, 'collections')
       expect(File.exist?(destination_path)).to eq false

--- a/spec/fixtures/diacritics/contents
+++ b/spec/fixtures/diacritics/contents
@@ -1,0 +1,3 @@
+MASSIE-KATIE-THESIS.pdf	bundle:ORIGINAL	primary:true
+MASSIE, Katie &apos;21_Re&#769;sume de ma The&#768;se_FINAL.pdf	bundle:CONTENT
+LICENSE.txt	bundle:LICENSE


### PR DESCRIPTION
When file names contain diacritics, DSpace is encoding them as HTML
entities in the contents file. We need to escape these in order to
accurately process the file.

Work toward https://github.com/pulibrary/dspace-development/issues/370