### PR TITLE
Fix embargo matching for very long titles

### DIFF
--- a/lib/etd_transformer/senior_theses_transformer.rb
+++ b/lib/etd_transformer/senior_theses_transformer.rb
@@ -199,12 +199,16 @@ module EtdTransformer
     end
 
     ##
-    # The titles contain extra data that will make them harder to match on. They need cleaning.
+    # The titles contain extra data that will make them harder to match on.
+    # They need cleaning.
     # Downcase, strip whitespace and punctuation.
+    # Truncate at 50 characters because the very long theses titles are more
+    # likely to diverge between ThesisCentral and the Embargo Spreadsheet.
     def normalize_title(title)
       newtitle = title.downcase
       newtitle = newtitle.split(' - ').first.strip
-      newtitle.gsub(/[^a-zA-Z\s\d]/, '')
+      newtitle = newtitle.gsub(/[^a-zA-Z\s\d]/, '')
+      newtitle[0, 50]
     end
 
     ##

--- a/spec/etd_transformer/embargo_data_point_spec.rb
+++ b/spec/etd_transformer/embargo_data_point_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe EtdTransformer::EmbargoDataPoint do
+  let(:restriction_status) { "Walk-In Only" }
   let(:spreadsheet_row) do
     {
       "Name" => "This is a fake creative writing thesis - Janice Cheon.xml",
@@ -12,7 +13,7 @@ RSpec.describe EtdTransformer::EmbargoDataPoint do
       "Adviser Comments Status" => "N/A", "Adviser Comments" => nil,
       "ODOCReview" => "Approved",
       "Confirmation Sent" => "Yes", "Approval Notification Sent" => "Yes",
-      "Mudd Status" => "Pending", "Request Type" => "Walk-In Only",
+      "Mudd Status" => "Pending", "Request Type" => restriction_status,
       "Notify Faculty Adviser" => nil, "Thesis Uploaded" => "No",
       "Check Thesis Uploaded" => "1", "SetFormLink" => nil,
       "Item Type" => "Item", "Path" => "our/strar/Requests"
@@ -20,16 +21,25 @@ RSpec.describe EtdTransformer::EmbargoDataPoint do
   end
   let(:embargo_data_point) { described_class.new(spreadsheet_row) }
 
-  it 'has the netid' do
-    expect(embargo_data_point.netid).to eq 'jcheon'
+  context "Request Type: Walk-In Only" do
+    it 'has the netid' do
+      expect(embargo_data_point.netid).to eq 'jcheon'
+    end
+    it 'has the title' do
+      expect(embargo_data_point.title).to eq spreadsheet_row["Name"]
+    end
+    it 'has the walk in access' do
+      expect(embargo_data_point.walk_in_access).to eq 'Yes'
+    end
+    it 'has the embargo years' do
+      expect(embargo_data_point.years).to eq '5'
+    end
   end
-  it 'has the title' do
-    expect(embargo_data_point.title).to eq spreadsheet_row["Name"]
-  end
-  it 'has the walk in access' do
-    expect(embargo_data_point.walk_in_access).to eq 'Yes'
-  end
-  it 'has the embargo years' do
-    expect(embargo_data_point.years).to eq '5'
+
+  context "Request Type: Embargo + Walk-In" do
+    let(:restriction_status) { "Embargo + Walk-In" }
+    it 'has the walk in access' do
+      expect(embargo_data_point.walk_in_access).to eq 'Yes'
+    end
   end
 end

--- a/spec/etd_transformer/senior_thesis_transformer_spec.rb
+++ b/spec/etd_transformer/senior_thesis_transformer_spec.rb
@@ -161,10 +161,12 @@ RSpec.describe EtdTransformer::SeniorThesesTransformer do
 
   # The titles as written in the embargo spreadsheet contain extra data that will
   # make them harder to match on. They need cleaning.
+  # They should also truncate to 50 characters because very long titles are more
+  # likely to have diverged.
   context 'title matching' do
     it 'eliminates capitalization, punctuation, and extra data' do
       original_title = '“THE WAY OUT”_ A Contemporary Portrait of 1.5 and Second Generation Immigrants from New York City’s  - Sanna Lee.xml'
-      normalized_title = 'the way out a contemporary portrait of 15 and second generation immigrants from new york citys'
+      normalized_title = 'the way out a contemporary portrait of 15 and seco'
       expect(transformer.normalize_title(original_title)).to eq normalized_title
     end
     it 'determines whether two strings match using Levenshtein distance' do
@@ -173,6 +175,11 @@ RSpec.describe EtdTransformer::SeniorThesesTransformer do
       expect(transformer.match?(title1, title2)).to eq true
       title2 = "a totally different title"
       expect(transformer.match?(title1, title2)).to eq false
+    end
+    it "matches very long titles" do
+      title1 = "Breaking the Species Barrier_ Investigating the Host Proteins Involved in Human and Murine Hepatitis - Mansi Totwani.xml"
+      title2 = "Breaking the Species Barrier: Investigating the Host Proteins Involved in Human and Murine Hepatitis B Infection"
+      expect(transformer.match?(title1, title2)).to eq true
     end
   end
 


### PR DESCRIPTION
Work toward https://github.com/pulibrary/etd_transformer/issues/124

Before this fix, the 2022 molecular biology theses had five embargoed items:

```
 bess@dali  ~/projects/senior_theses/2022/output/molecular_biology  grep -r "embargo" *
submission_10889/metadata_pu.xml:  <dcvalue element="embargo" qualifier="terms">2024-07-01</dcvalue>
submission_10944/metadata_pu.xml:  <dcvalue element="embargo" qualifier="terms">2024-07-01</dcvalue>
submission_11267/metadata_pu.xml:  <dcvalue element="embargo" qualifier="terms">2024-07-01</dcvalue>
submission_11324/metadata_pu.xml:  <dcvalue element="embargo" qualifier="terms">2024-07-01</dcvalue>
submission_11701/metadata_pu.xml:  <dcvalue element="embargo" qualifier="terms">2024-07-01</dcvalue>
``` 

After the fix there are eight, which is the expected number:

```
bess@dali  ~/projects/senior_theses/2022/output/molecular_biology  cd ~/projects/senior_theses/debugging/output/
 bess@dali  ~/projects/senior_theses/debugging/output  grep -r "embargo" *
submission_10889/metadata_pu.xml:  <dcvalue element="embargo" qualifier="terms">2024-07-01</dcvalue>
submission_10944/metadata_pu.xml:  <dcvalue element="embargo" qualifier="terms">2024-07-01</dcvalue>
submission_11267/metadata_pu.xml:  <dcvalue element="embargo" qualifier="terms">2024-07-01</dcvalue>
submission_11324/metadata_pu.xml:  <dcvalue element="embargo" qualifier="terms">2024-07-01</dcvalue>
submission_11635/metadata_pu.xml:  <dcvalue element="embargo" qualifier="terms">2024-07-01</dcvalue>
submission_11682/metadata_pu.xml:  <dcvalue element="embargo" qualifier="terms">2024-07-01</dcvalue>
submission_11701/metadata_pu.xml:  <dcvalue element="embargo" qualifier="terms">2024-07-01</dcvalue>
submission_12201/metadata_pu.xml:  <dcvalue element="embargo" qualifier="terms">2024-07-01</dcvalue>
```